### PR TITLE
[Dupe and Comment] Fix selected / active line and one more bug

### DIFF
--- a/macros/garret.dupe-and-comment.lua
+++ b/macros/garret.dupe-and-comment.lua
@@ -5,29 +5,26 @@ script_version = "2.1.3"
 script_namespace = "garret.dupe-and-comment"
 
 local haveDepCtrl, DependencyControl, depctrl = pcall(require, "l0.DependencyControl")
-local util
 if haveDepCtrl then
-    depctrl = DependencyControl {
-        --feed="TODO",
-        {"aegisub.util"}
-    }
-    util = depctrl:requireModules()
-else
-    util = require 'aegisub.util'
+    depctrl = DependencyControl({})
+    depctrl:requireModules()
 end
 
-local function comment(subs, sel)
+local function comment(subs, sel, act)
     for i=#sel,1,-1 do
         local line=subs[sel[i]]
-        local original = util.copy(line)
-        line.comment = false -- going to edit it, so we probably want to see it on the video
-        original.comment = true -- this is the actual original one
-        subs.insert(sel[i]+1, original) -- putting it on the next line so i don't have to change line
+        line.comment = false
+        subs[sel[i]] = line
+        line.comment = true
+        subs.insert(sel[i]+1, line)
+        for j=i+1,#sel do sel[j] = sel[j] + 1 end
+        if act > sel[i] then act = act + 1 end
     end
     aegisub.set_undo_point(script_name)
+    return sel, act
 end
 
-local function undo(subs, sel)
+local function undo(subs, sel, act)
     for i=#sel,1,-1 do
         local edit=subs[sel[i]]
         if not (sel[i] + 1 > #subs) then
@@ -36,10 +33,13 @@ local function undo(subs, sel)
                 original.comment = false
                 subs[sel[i]+1] = original
                 subs.delete(sel[i])
+                for j=i+1,#sel do sel[j] = sel[j] - 1 end
+                if act > sel[i] then act = act - 1 end
             end
         end
     end
     aegisub.set_undo_point("Undo "..script_name)
+    return sel, act
 end
 
 local macros = {


### PR DESCRIPTION
Changes:  
* *Selected lines and active line will now be properly set after do and undo.*  
* *Commented line will now be properly uncommented after do.*  
    There is a bug in the previous implementation. According to [Aegisub documentation](https://web.archive.org/web/20200217233603/http://docs.aegisub.org/3.2/Automation/Lua/Subtitle_file_interface/), line is a copy of the original line in the subtitle object and not a reference. The code for it can be found [here](https://github.com/arch1t3cht/Aegisub/blob/feature/src/auto4_lua_assfile.cpp#L148-L239).  
* *aegisub.util is no longer required by do and is removed from DepCtrl's requiredModules.*  

I've done some basic tests and I think it is working as expected. Version number is left unchanged.  
Sorry for being stubborn and arguing with everyone yesterday.  
Thank you :D  